### PR TITLE
Fixes creation of incorrect SIP PhoneAccountHandle

### DIFF
--- a/sip/src/com/android/services/telephony/sip/SipAccountRegistry.java
+++ b/sip/src/com/android/services/telephony/sip/SipAccountRegistry.java
@@ -67,7 +67,7 @@ public final class SipAccountRegistry {
                     sipManager.open(
                             mProfile,
                             SipUtil.createIncomingCallPendingIntent(context,
-                                    mProfile.getUriString()),
+                                    mProfile.getProfileName()),
                             null);
                 } else {
                     sipManager.open(mProfile);

--- a/sip/src/com/android/services/telephony/sip/SipUtil.java
+++ b/sip/src/com/android/services/telephony/sip/SipUtil.java
@@ -55,10 +55,10 @@ public class SipUtil {
     }
 
     static PendingIntent createIncomingCallPendingIntent(
-            Context context, String sipUri) {
+            Context context, String sipProfileName) {
         Intent intent = new Intent(context, SipBroadcastReceiver.class);
         intent.setAction(SipManager.ACTION_SIP_INCOMING_CALL);
-        intent.putExtra(EXTRA_PHONE_ACCOUNT, SipUtil.createAccountHandle(context, sipUri));
+        intent.putExtra(EXTRA_PHONE_ACCOUNT, SipUtil.createAccountHandle(context, sipProfileName));
         return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
     }
 


### PR DESCRIPTION
When a new incoming call occurs in SIP, SipUtil mistakenly uses the
Uri handle instead of the profile name to create the
PhoneAccountHandle. Since this PhoneAccountHandle is not registered
with telecom, it will throw a security exception (as of b/26864502).

BUG: 26874216
Change-Id: I27611b45f0834fca328c4cc2b867edaf970f7171
